### PR TITLE
Add script to fetch Cyprus GTFS bus arrivals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# bus_stop_info
+# Bus Stop Info
+
+This repository provides a simple script to display live bus arrival times for a stop in Cyprus using a GTFS-realtime feed.
+
+## Requirements
+- Python 3
+- `requests`
+- `gtfs-realtime-bindings`
+
+Install dependencies with:
+
+```bash
+pip install requests gtfs-realtime-bindings
+```
+
+## Usage
+Set the following environment variables:
+
+- `API_URL` – URL to the GTFS-realtime TripUpdates feed provided by Cyprus Public Transport.
+- `API_KEY` – API key if required (optional).
+- `STOP_ID` – ID of the stop to monitor.
+
+Run the script:
+
+```bash
+python display_board.py
+```
+
+The script prints the next few arrival times in minutes. Modify `update_board` in `display_board.py` to send the information to your hardware display.
+

--- a/display_board.py
+++ b/display_board.py
@@ -1,0 +1,50 @@
+import os
+import time
+import requests
+from google.transit import gtfs_realtime_pb2
+
+API_URL = os.environ.get('API_URL', 'https://api.example.com/gtfs-rt/TripUpdates')
+API_KEY = os.environ.get('API_KEY')
+
+STOP_ID = os.environ.get('STOP_ID', '1234')
+
+HEADERS = {}
+if API_KEY:
+    HEADERS['Authorization'] = f'Bearer {API_KEY}'
+
+
+def fetch_feed():
+    resp = requests.get(API_URL, headers=HEADERS, timeout=10)
+    resp.raise_for_status()
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.ParseFromString(resp.content)
+    return feed
+
+
+def get_arrivals(feed, stop_id):
+    arrivals = []
+    now = int(time.time())
+    for entity in feed.entity:
+        if not entity.HasField('trip_update'):
+            continue
+        for stu in entity.trip_update.stop_time_update:
+            if stu.stop_id == stop_id and stu.HasField('arrival') and stu.arrival.time >= now:
+                arrivals.append(stu.arrival.time)
+    arrivals.sort()
+    return [t - now for t in arrivals]
+
+
+def update_board(arrivals):
+    for i, seconds in enumerate(arrivals[:5], start=1):
+        minutes = seconds // 60
+        print(f"Bus {i} arriving in {minutes} min")
+
+
+def main():
+    feed = fetch_feed()
+    arrivals = get_arrivals(feed, STOP_ID)
+    update_board(arrivals)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `display_board.py` to read a GTFS realtime TripUpdates feed
- document how to configure and run the script in README

## Testing
- `python display_board.py` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876a6c86d30832e92741ddf0517b3df