### PR TITLE
Improve feed handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# bus_stop_info
+# Bus Stop Info
+
+This repository provides a simple script to display live bus arrival times for a stop in Cyprus using a GTFS-realtime feed.
+
+## Requirements
+- Python 3
+- `requests`
+- `gtfs-realtime-bindings`
+- `flask`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Set the following environment variables:
+
+- `API_URL` – URL to the GTFS-realtime TripUpdates feed provided by Cyprus Public Transport.
+- `API_KEY` – API key if required (optional).
+- `STOP_ID` – ID of the stop to monitor.
+
+Run the script:
+
+```bash
+python display_board.py
+```
+
+The script prints the next few arrival times in minutes. If the network request
+fails, it falls back to reading `sample_trip_update.pb`. Modify `update_board` in
+`display_board.py` to send the information to your hardware display.
+
+## Web Front End
+
+To preview how the board might look, run the small web server and open a
+browser to `http://localhost:8000`:
+
+```bash
+python web_board.py
+```
+
+The page refreshes automatically every 30 seconds and shows the upcoming bus
+arrivals.
+

--- a/display_board.py
+++ b/display_board.py
@@ -1,0 +1,77 @@
+import os
+import time
+import requests
+from google.transit import gtfs_realtime_pb2
+from requests.exceptions import RequestException
+from google.protobuf import text_format
+
+API_URL = os.environ.get('API_URL', 'https://api.example.com/gtfs-rt/TripUpdates')
+API_KEY = os.environ.get('API_KEY')
+
+STOP_ID = os.environ.get('STOP_ID', '1234')
+LOCAL_FEED = os.environ.get('LOCAL_FEED', 'sample_trip_update.pb')
+
+HEADERS = {}
+if API_KEY:
+    HEADERS['Authorization'] = f'Bearer {API_KEY}'
+
+
+def fetch_feed():
+    """Fetch TripUpdates feed.
+
+    If the request fails, fall back to reading a local feed file defined by
+    ``LOCAL_FEED``.
+    """
+    feed = gtfs_realtime_pb2.FeedMessage()
+    try:
+        resp = requests.get(API_URL, headers=HEADERS, timeout=10)
+        resp.raise_for_status()
+        feed.ParseFromString(resp.content)
+    except RequestException as exc:
+        print(
+            f"Warning: failed to download feed ({exc}). Using local file '{LOCAL_FEED}'."
+        )
+        with open(LOCAL_FEED, "rb") as fh:
+            data = fh.read()
+            try:
+                feed.ParseFromString(data)
+            except Exception:
+                text_format.Parse(data.decode("utf-8"), feed)
+    return feed
+
+
+def get_arrivals(feed, stop_id):
+    """Return a list of arrival times in seconds from now for ``stop_id``."""
+    arrivals = []
+    now = int(time.time())
+    for entity in feed.entity:
+        if not entity.HasField('trip_update'):
+            continue
+        for stu in entity.trip_update.stop_time_update:
+            if stu.stop_id == stop_id and stu.HasField('arrival') and stu.arrival.time >= now:
+                arrivals.append(stu.arrival.time)
+    arrivals.sort()
+    return [t - now for t in arrivals]
+
+
+def update_board(arrivals):
+    """Print arrival information.
+
+    Replace this function with code that updates your physical display.
+    """
+    for i, seconds in enumerate(arrivals[:5], start=1):
+        minutes = seconds // 60
+        print(f"Bus {i} arriving in {minutes} min")
+
+
+def main():
+    feed = fetch_feed()
+    arrivals = get_arrivals(feed, STOP_ID)
+    if arrivals:
+        update_board(arrivals)
+    else:
+        print("No upcoming arrivals found.")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+gtfs-realtime-bindings
+flask

--- a/sample_trip_update.pb
+++ b/sample_trip_update.pb
@@ -1,0 +1,79 @@
+# header information
+header {
+  # version of speed specification. Currently "2.0". Valid versions are "2.0", "1.0".
+  gtfs_realtime_version: "2.0"
+  # determines whether dataset is incremental or full
+  incrementality: FULL_DATASET
+  # the moment where this dataset was generated on server
+  timestamp: 1284457468
+}
+
+# multiple entities can be included in the feed
+entity {
+  # unique identifier for the entity
+  id: "simple-trip"
+
+  # "type" of the entity
+  trip_update {
+    trip {
+      # selects which GTFS entity (trip) will be affected
+      trip_id: "trip-1"
+    }
+    # schedule information update
+    stop_time_update {
+      # selecting which stop is affected
+      stop_sequence: 3
+      # for the vehicle's arrival time
+      arrival {
+        # to be delayed with 5 seconds
+        delay: 5
+      }
+    }
+    # ...this vehicle's delay is propagated to its subsequent stops.
+
+    # Next information update on the vehicle's schedule
+    stop_time_update {
+      # selected by stop_sequence. It will update
+      stop_sequence: 8
+      # the vehicle's original (scheduled) arrival time with a
+      arrival {
+        # 1 second delay.
+        delay: 1
+      }
+    }
+    # ...likewise the delay is propagated to subsequent stops.
+
+    # Next information update on the vehicle's schedule
+    stop_time_update {
+      # selected by stop_sequence. It will update the vehicle's arrival time
+      stop_sequence: 10
+      # with the default delay of 0 (on time) and propagate this update
+      # for the rest of the vehicle's stops.
+    }
+  }
+}
+
+# second entity containing update information for another trip
+entity {
+  id: "3"
+  trip_update {
+    trip {
+      # frequency based trips are defined by their
+      # trip_id in GTFS and
+      trip_id: "frequency-expanded-trip"
+      # start_time
+      start_time: "11:15:35"
+    }
+    stop_time_update {
+      stop_sequence: 1
+      arrival {
+        # negative delay means vehicle is 2 seconds ahead of schedule
+        delay: -2
+      }
+    }
+    stop_time_update {
+      stop_sequence: 9
+    }
+  }
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Bus Stop Board</title>
+    <style>
+        body { font-family: sans-serif; text-align: center; }
+        h1 { margin-top: 40px; }
+        #arrivals { font-size: 2em; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Next Buses</h1>
+    <div id="arrivals">Loading...</div>
+    <script>
+        async function fetchArrivals() {
+            const resp = await fetch('/arrivals');
+            const data = await resp.json();
+            const arrivals = data.arrivals;
+            const div = document.getElementById('arrivals');
+            if (arrivals.length === 0) {
+                div.textContent = 'No upcoming arrivals';
+            } else {
+                div.innerHTML = arrivals.map(m => `Bus in ${m} min`).join('<br>');
+            }
+        }
+        fetchArrivals();
+        setInterval(fetchArrivals, 30000);
+    </script>
+</body>
+</html>

--- a/web_board.py
+++ b/web_board.py
@@ -1,0 +1,21 @@
+import os
+from flask import Flask, jsonify, render_template
+from display_board import fetch_feed, get_arrivals
+
+app = Flask(__name__)
+STOP_ID = os.environ.get("STOP_ID", "1234")
+
+@app.route("/arrivals")
+def arrivals():
+    feed = fetch_feed()
+    arrs = get_arrivals(feed, STOP_ID)
+    minutes = [sec // 60 for sec in arrs]
+    return jsonify(arrivals=minutes)
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))


### PR DESCRIPTION
## Summary
- add sample GTFS feed and requirements.txt
- enhance `display_board.py` to use a local feed if the network request fails
- document new setup instructions
- add simple web interface for previewing arrivals

## Testing
- `pip install -r requirements.txt`
- `python display_board.py`
- `python -m py_compile display_board.py web_board.py`
- `python web_board.py` *(manual check via curl)*


------
https://chatgpt.com/codex/tasks/task_e_6876a6c86d30832e92741ddf0517b3df